### PR TITLE
Changes to have the window look forward, not centered

### DIFF
--- a/src/hampel/extension/hampel.pyx
+++ b/src/hampel/extension/hampel.pyx
@@ -40,8 +40,9 @@ def hampel(np.ndarray[np.float32_t, ndim=1] data, int window_size, float n_sigma
 
     cdef int num_outliers = 0
 
-    for i in range(half_window, data_len - half_window):
-        window = data[i - half_window: i + half_window + 1].copy()
+#    for i in range(half_window, data_len - half_window):
+    for i in range(0, data_len - window_size):
+        window = data[i: i + window_size].copy()
         window_length = len(window)
         median = np.median(window)
 


### PR DESCRIPTION
I used the library to filter impact data that inherently has sudden spikes that I want to keep. In the example bellow one can see, that the filter currently overfilters by removing the first few peaks in the series. I fixed this by changing the window to look forward. An option in the library with different window types would be nice to have as a feature.

![2024-02-06_12-31](https://github.com/MichaelisTrofficus/hampel_filter/assets/63401707/650bd388-f219-4579-8d16-4a29ceb914af)
